### PR TITLE
require bit32 if bit is not available

### DIFF
--- a/mmdb.lua
+++ b/mmdb.lua
@@ -1,6 +1,6 @@
 -- This implements a lua parser of http://maxmind.github.io/MaxMind-DB/
 
-local ok, bit = pcall(function() require "bit" end)
+local ok, bit = pcall(function() return require "bit" end)
 if not ok then bit = require "bit32" end
 local has_ffi , ffi = pcall ( require , "ffi" )
 

--- a/mmdb.lua
+++ b/mmdb.lua
@@ -1,7 +1,7 @@
 -- This implements a lua parser of http://maxmind.github.io/MaxMind-DB/
 
-local _, bit = pcall(function() require "bit" end)
-if not bit then _, bit = require "bit32" end
+local ok, bit = pcall(function() require "bit" end)
+if not ok then bit = require "bit32" end
 local has_ffi , ffi = pcall ( require , "ffi" )
 
 local mmdb_seperator = "\171\205\239MaxMind.com"

--- a/mmdb.lua
+++ b/mmdb.lua
@@ -1,6 +1,7 @@
 -- This implements a lua parser of http://maxmind.github.io/MaxMind-DB/
 
-local bit = require "bit"
+local _, bit = pcall(function() require "bit" end)
+if not bit then _, bit = require "bit32" end
 local has_ffi , ffi = pcall ( require , "ffi" )
 
 local mmdb_seperator = "\171\205\239MaxMind.com"


### PR DESCRIPTION
"bit" is not available in lua 5.2, but "bit32" is.
