### PR TITLE
Add. `safe` mode to mmdb object

### DIFF
--- a/geo.lua
+++ b/geo.lua
@@ -1,0 +1,50 @@
+#!/usr/bin/env ujit
+
+local argparse = require "argparse"
+local mmdb     = require "mmdb"
+local json     = require "dkjson"
+
+local function get_args()
+    local parser = argparse("geo", "Get info from MMDB database")
+
+    parser:argument("ip", "IP v4/v6 address"):args "?"
+
+    parser:flag("-i --info", "Infromation about database")
+
+    parser
+        :option("-d --mmdb", "MaxMind2 database", "/usr/share/GeoIP/GeoIP2-City.mmdb")
+
+    return parser:parse()
+end
+
+local args = get_args()
+
+local geodb, err = mmdb.read(args.mmdb, true)
+if not geodb then
+    io.stderr:write(err)
+    os.exit(-1)
+end
+
+if args.info then
+    io.stdout:write(string.format(
+        "%s (%s); Support IPv%d; Nodes: %d\n",
+        geodb.data.database_type,
+        os.date("%F %T%z", tonumber(geodb.data.build_epoch)),
+        geodb.data.ip_version,
+        geodb.data.node_count
+    ))
+end
+
+if args.ip then
+    local info
+    if string.find(args.ip, ':') then
+        info = geodb:search_ipv6(args.ip)
+    else
+        info = geodb:search_ipv4(args.ip)
+    end
+    if not info then
+        io.stderr:write('Not found info: ' .. args.ip)
+        os.exit(-2)
+    end
+    io.stdout:write(json.encode(info, { indent = true }))
+end

--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -21,12 +21,16 @@ end
 
 local function open_db(safe, filename)
 	local fd, err = io.open(filename, "rb")
-	if not fd then return fail(safe, err) end
+	if not fd then
+		return fail(safe, err)
+	end
 
 	local contents, err = fd:read("*a")
 	fd:close()
 
-	if not contents then return fail(safe, err) end
+	if not contents then
+		return fail(safe, err)
+	end
 
 	local start_metadata do
 		-- Find data section seperator; at most it's 128kb from the end
@@ -56,7 +60,7 @@ local function open_db(safe, filename)
 
 	local getter = getters[data.record_size]
 	if getter == nil then
-		return self:fail("Unsupported record size: " .. tostring(data.record_size))
+		return fail(self.safe, "Unsupported record size: " .. tostring(data.record_size))
 	end
 	self.left, self.right, self.record_length = getter.left, getter.right, getter.record_length
 
@@ -67,10 +71,6 @@ local function open_db(safe, filename)
 	end
 
 	return self
-end
-
-function geodb_methods:fail(...)
-	return fail(self.safe, ...)
 end
 
 function geodb_methods:read_data(base, offset)
@@ -381,7 +381,9 @@ end
 
 local function ipv4_to_bit_array(str)
 	local o1, o2, o3, o4 = str:match("(%d%d?%d?)%.(%d%d?%d?)%.(%d%d?%d?)%.(%d%d?%d?)")
-	if not o1 then return "invalid IPv4 address" end
+	if not o1 then
+		return nil, "invalid IPv4 address"
+	end
 	o1 = tonumber(o1, 10)
 	o2 = tonumber(o2, 10)
 	o3 = tonumber(o3, 10)
@@ -428,7 +430,9 @@ end
 
 function geodb_methods:search_ipv4(str)
 	local bits, err = ipv4_to_bit_array(str)
-	if not bits then return self:fail(err) end
+	if not bits then
+		return fail(self.safe, err)
+	end
 	return select(2, self:search(bits, self.ipv4_start))
 end
 
@@ -459,7 +463,9 @@ local function ipv6_to_bit_array(str)
 			components[i] = end_components[i-8+m]
 		end
 	else
-		if n ~= 8 then return nil, "invalid IPv6 address" end
+		if n ~= 8 then
+			return nil, "invalid IPv6 address"
+		end
 	end
 	-- Now components is an array of 16bit components
 	local bits = {}
@@ -474,7 +480,9 @@ end
 
 function geodb_methods:search_ipv6(str)
 	local bits, err = ipv6_to_bit_array(str)
-	if not bits then return self:fail(err) end
+	if not bits then
+		return fail(self.safe, err)
+	end
 	return select(2, self:search(bits))
 end
 

--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -23,7 +23,7 @@ end
 
 local function new(contents, safe)
 	if not contents then
-		return fail(safe, err)
+		return fail(safe, "No MaxMind Database content")
 	end
 
 	local start_metadata do

--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -15,7 +15,9 @@ local data_types = {}
 local getters = {}
 
 local function fail(safe, ...)
-	if safe then return nil, ... end
+	if safe then
+		return nil, ...
+	end
 	error(..., 2)
 end
 

--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -494,7 +494,15 @@ function geodb_methods:search_ipv6(str)
 	return select(2, self:search(bits))
 end
 
+local function open(...)
+	return open_db(false, ...)
+end
+
+local function open_safe(...)
+	return open_db(true, ...)
+end
+
 return {
-	open = function(...) return open_db(false, ...) end;
-	open_safe = function(...) return open_db(true, ...) end;
+	open = open;
+	open_safe = open_safe;
 }

--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -442,7 +442,9 @@ local function ipv6_split(str)
 	for u16 in str:gmatch("(%x%x?%x?%x?):?") do
 		n = n + 1
 		u16 = tonumber(u16, 16)
-		if not u16 then return nil, "invalid IPv6 address" end
+		if not u16 then
+			return nil, "invalid IPv6 address"
+		end
 		components[n] = u16
 	end
 	return components, n
@@ -451,11 +453,17 @@ end
 local function ipv6_to_bit_array(str)
 	local a, b = str:match("^([%x:]-)::([%x:]*)$")
 	local components, n = ipv6_split(a or str)
-	if not components then return nil, n end
+	if not components then
+		return nil, n
+	end
 	if a ~= nil then
 		local end_components, m = ipv6_split(b)
-		if not end_components then return nil, m end
-		if m+n > 7 then return nil, "invalid IPv6 address" end
+		if not end_components then
+			return nil, m
+		end
+		if m+n > 7 then
+			return nil, "invalid IPv6 address"
+		end
 		for i = n+1, 8-m do
 			components[i] = 0
 		end

--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -333,10 +333,10 @@ getters[32] = {
 function geodb_methods:search(bits, node)
 	node = node or 0
 	local seen = { [node] = true }
-	for i = 1, #bits do
+	for _, direction in ipairs(bits) do
 		local offset = node * self.record_length + 1
 		local record_value
-		if bits[i] then
+		if direction then
 			record_value = self:right(offset)
 		else
 			record_value = self:left(offset)


### PR DESCRIPTION
I only add safe way to handle invalid input.
Usage
```Lua
local db, err = mmdb.open_safe("GeoLite2-City.mmdb")
assert(db, err)
local info, err = db:search_ipv4('192.168.123.1')
if err  then -- error 
if not info then -- item not found
```

Not sure is it worth convert also errors based on invalid database. 
This list of rest errors
```Lua
assert(length == 8, "double of non-8 length") 
assert(length == 8, "double of non-8 length")
assert(type(key) == "string") 
error("Unknown data section: " .. data_type)
error("Cyclical tree") 
```
I think it should be converted too. 
Only problem it requires few more `if` for each call read_data
