### PR TITLE
fix boolean type offset [maxmind GeoIP2-Anonymous-database not working #12]

### DIFF
--- a/mmdb/init.lua
+++ b/mmdb/init.lua
@@ -279,9 +279,9 @@ data_types[13] = function(self, base, offset, zero) -- luacheck: ignore 212
 	return nil
 end
 
--- Boolean
+-- Boolean: The length information for a boolean type will always be 0 or 1, indicating the value. There is no payload for this field.
 data_types[14] = function(self, base, offset, length) -- luacheck: ignore 212
-	return offset + length, length == 1
+	return offset, length == 1
 end
 
 getters[24] = {


### PR DESCRIPTION
Maxmind db boolean type description

> "boolean 14 - A true or false value. The length information for a boolean type will always be 0 or 1, indicating the value. There is no payload for this field."

There is no payload for boolean type, so offset shouldn't be incremented by length.
Guess this breaks for all database having boolean values. Tested with Maxmind Anonymous IP and City database seem to be working fine.

Please let me know if i could help with any other testing.
@daurnimator 